### PR TITLE
Dependencies: update to IDEA 2023.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
+#
 # SPDX-FileCopyrightText: 2026 haskeletor contributors <https://github.com/ForNeVeR/haskeletor>
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 pluginVersion=1.0.0
-pluginSinceBuild=223
-platformVersion=2022.3
+platformVersion=2023.3

--- a/src/main/scala/me/fornever/haskeletor/navigation/HaskellStructureViewFactory.scala
+++ b/src/main/scala/me/fornever/haskeletor/navigation/HaskellStructureViewFactory.scala
@@ -48,15 +48,15 @@ private class HaskellStructureViewTreeElement(val element: PsiElement, val typeS
     element
   }
 
-  def navigate(requestFocus: Boolean): Unit = {
+  override def navigate(requestFocus: Boolean): Unit = {
     element.asInstanceOf[Navigatable].navigate(requestFocus)
   }
 
-  def canNavigate: Boolean = {
+  override def canNavigate: Boolean = {
     element.asInstanceOf[Navigatable].canNavigate
   }
 
-  def canNavigateToSource: Boolean = {
+  override def canNavigateToSource: Boolean = {
     element.asInstanceOf[Navigatable].canNavigateToSource
   }
 


### PR DESCRIPTION
This is a workaround for https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2118.

But we need to update the IDE version eventually anyway.