### PR TITLE
`HaskellConfigurable`: move the name into the registration

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -199,10 +199,11 @@
                 implementation="me.fornever.haskeletor.spellchecker.HaskellBundledDictionaryProvider"/>
 
         <!-- Configuration -->
-        <applicationConfigurable
-                groupId="language"
-                id="Haskell.Configurable"
-                instance="me.fornever.haskeletor.settings.HaskellConfigurable"/>
+        <applicationConfigurable groupId="language"
+                                 id="Haskell.Configurable"
+                                 instance="me.fornever.haskeletor.settings.HaskellConfigurable"
+                                 bundle="messages.HaskeletorBundle"
+                                 key="configurable.haskell.title"/>
         <applicationService serviceImplementation="me.fornever.haskeletor.settings.HaskellSettingsPersistentStateComponent"/>
         <framework.type implementation="me.fornever.haskeletor.framework.HaskellFrameworkType"/>
         <lang.importOptimizer language="Haskell" implementationClass="me.fornever.haskeletor.editor.HaskellImportOptimizer"/>

--- a/src/main/resources/messages/HaskeletorBundle.properties
+++ b/src/main/resources/messages/HaskeletorBundle.properties
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-stack.install.title=Installing {0}
-stack.progress.text={0}: {1} / {2} packages
-stack.progress.packages-in-progress=Processing: {0} {1,choice,0#|0<and {1} other}
+configurable.haskell.title=Haskell
+
+progress.installing-tool.title=Installing {0}
+progress.installing-tool.text={0}: {1} / {2} packages
+progress.installing-tool.in-progress=Processing: {0} {1,choice,0#|0<and {1} other}

--- a/src/main/scala/me/fornever/haskeletor/HaskeletorBundle.scala
+++ b/src/main/scala/me/fornever/haskeletor/HaskeletorBundle.scala
@@ -7,9 +7,11 @@
 package me.fornever.haskeletor
 
 import com.intellij.DynamicBundle
-import org.jetbrains.annotations.PropertyKey
+import org.jetbrains.annotations.{Nls, PropertyKey}
 
 object HaskeletorBundle extends DynamicBundle(HaskeletorBundle.BUNDLE) {
   private final val BUNDLE = "messages.HaskeletorBundle"
+
+  @Nls
   def message(@PropertyKey(resourceBundle = BUNDLE) key: String, params: Any*): String = getMessage(key, params: _*)
 }

--- a/src/main/scala/me/fornever/haskeletor/external/execution/CommandLine.scala
+++ b/src/main/scala/me/fornever/haskeletor/external/execution/CommandLine.scala
@@ -173,7 +173,7 @@ private class CapturingProcessToProgressIndicator(@Nls title: String, progressIn
       case PackageStatus(_, _) => ()
       case Progress(done, total, packagesInProgress) =>
         progressIndicator.setFraction(done.toDouble / total.toDouble)
-        progressIndicator.setText(HaskeletorBundle.message("stack.progress.text", title, done, total))
+        progressIndicator.setText(HaskeletorBundle.message("progress.installing-tool.text", title, done, total))
         progressIndicator.setText2(packagesInProgress match {
           case Seq() =>
             //noinspection ScalaExtractStringToBundle
@@ -182,7 +182,7 @@ private class CapturingProcessToProgressIndicator(@Nls title: String, progressIn
             val packagesToShow = packagesInProgress.take(3)
             val packagesToShowText = NlsMessages.formatNarrowAndList(packagesToShow.asJava)
             val otherPackageCount = packagesInProgress.size - packagesToShow.size
-            HaskeletorBundle.message("stack.progress.packages-in-progress", packagesToShowText, otherPackageCount)
+            HaskeletorBundle.message("progress.installing-tool.in-progress", packagesToShowText, otherPackageCount)
         })
     }
 

--- a/src/main/scala/me/fornever/haskeletor/external/execution/StackCommandLine.scala
+++ b/src/main/scala/me/fornever/haskeletor/external/execution/StackCommandLine.scala
@@ -96,7 +96,7 @@ object StackCommandLine {
       project,
       workDir = Some(VfsUtil.getUserHomeDir.getPath),
       arguments,
-      HaskeletorBundle.message("stack.install.title", toolName),
+      HaskeletorBundle.message("progress.installing-tool.title", toolName),
       Some(progressIndicator)
     ).exists(handler => {
 

--- a/src/main/scala/me/fornever/haskeletor/settings/HaskellConfigurable.scala
+++ b/src/main/scala/me/fornever/haskeletor/settings/HaskellConfigurable.scala
@@ -11,6 +11,7 @@ package me.fornever.haskeletor.settings
 import com.intellij.openapi.options.{Configurable, ConfigurationException}
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.ui.DocumentAdapter
+import me.fornever.haskeletor.HaskeletorBundle
 
 import java.awt.{GridBagConstraints, GridBagLayout, Insets}
 import javax.swing._
@@ -32,9 +33,7 @@ class HaskellConfigurable extends Configurable {
   private val extraStackArgumentsField = new JTextField
   private val defaultGhcOptionsField = new JTextField
 
-  override def getDisplayName: String = {
-    "Haskell"
-  }
+  override def getDisplayName: String = HaskeletorBundle.message("configurable.haskell.title")
 
   override def isModified: Boolean = this.isModifiedByUser
 


### PR DESCRIPTION
Closes #21.