### PR TITLE
HaskellEditorUtil: remove the catch-all block & code cleanup

### DIFF
--- a/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
+++ b/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
@@ -11,24 +11,17 @@ package me.fornever.haskeletor.util
 import com.intellij.codeInsight.hint.{HintManager, HintManagerImpl, HintUtil}
 import com.intellij.openapi.actionSystem.{AnActionEvent, CommonDataKeys}
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.util.BaseListPopupStep
-import com.intellij.openapi.ui.popup.{Balloon, JBPopupFactory}
+import com.intellij.openapi.util.NlsContexts.HintText
 import com.intellij.openapi.wm.WindowManager
-import com.intellij.openapi.wm.ex.StatusBarEx
-import com.intellij.psi.{PsiElement, PsiFile}
 import com.intellij.ui.LightweightHint
-import com.intellij.ui.awt.RelativePoint
+import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.UIUtil.FontSize
-import com.intellij.util.ui.{PositionTracker, UIUtil}
 import me.fornever.haskeletor.HaskellFile
 
-import java.awt.Point
 import java.awt.event.{MouseEvent, MouseMotionAdapter}
-import javax.swing.Icon
-import javax.swing.event.HyperlinkListener
 import scala.jdk.CollectionConverters._
 
 object HaskellEditorUtil {
@@ -70,7 +63,7 @@ object HaskellEditorUtil {
     }
   }
 
-  def showHint(editor: Editor, text: String, sticky: Boolean = false): Unit = {
+  def showHint(editor: Editor, @HintText text: String, sticky: Boolean = false): Unit = {
     val label = HintUtil.createInformationLabel(text)
     label.setFont(UIUtil.getLabelFont(FontSize.NORMAL))
 
@@ -96,32 +89,9 @@ object HaskellEditorUtil {
     hintManager.showEditorHint(hint, editor, point, hideFlags, 0, false, hintHint)
   }
 
-  def showInfoMessageBalloon(message: String, editor: Editor, inCenterOfEditor: Boolean): Unit = {
-    UIUtil.invokeLaterIfNeeded(() => {
-      val balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(message, MessageType.INFO, null).setCloseButtonEnabled(true).setHideOnAction(true).createBalloon()
-      if (inCenterOfEditor) {
-        balloon.showInCenterOf(editor.getComponent)
-      } else {
-        balloon.show(new PositionTracker[Balloon](editor.getContentComponent) {
-          def recalculateLocation(balloon: Balloon): RelativePoint = {
-            val popupFactory = JBPopupFactory.getInstance
-            val target: RelativePoint = popupFactory.guessBestPopupLocation(editor)
-            val screenPoint: Point = target.getScreenPoint
-            var y: Int = screenPoint.y
-            if (target.getPoint.getY > editor.getLineHeight + balloon.getPreferredSize.getHeight) {
-              y -= editor.getLineHeight
-            }
-            val relativePoint = new RelativePoint(new Point(screenPoint.x, y))
-            relativePoint
-          }
-        }, Balloon.Position.above)
-      }
-    })
-  }
-
   def showList(messages: Seq[String], editor: Editor): Unit = {
     UIUtil.invokeLaterIfNeeded(() => {
-      val listPopupStep = new BaseListPopupStep[String]("info", messages.asJava) {
+      val listPopupStep: BaseListPopupStep[String] = new BaseListPopupStep[String]("info", messages.asJava) {
         override def isSpeedSearchEnabled: Boolean = true
       }
       val listPopup = JBPopupFactory.getInstance().createListPopup(listPopupStep)
@@ -134,28 +104,6 @@ object HaskellEditorUtil {
       wm <- Option(WindowManager.getInstance())
       sb <- Option(wm.getStatusBar(project))
     } yield sb.setInfo(message)
-  }
-
-  def showStatusBarBalloonMessage(project: Project, message: String): Unit = {
-    UIUtil.invokeLaterIfNeeded(() => {
-      def run() = {
-        for {
-          wm <- Option(WindowManager.getInstance)
-          f <- Option(wm.getIdeFrame(project))
-          statusBar <- Option(f.getStatusBar.asInstanceOf[StatusBarEx])
-        } yield {
-          statusBar.isProcessWindowOpen
-          statusBar.notifyProgressByBalloon(MessageType.WARNING, message, null.asInstanceOf[Icon], null.asInstanceOf[HyperlinkListener])
-        }
-      }
-
-      run()
-    })
-  }
-
-  def findCurrentElement(psiFile: PsiFile): Option[PsiElement] = {
-    val offset = Option(FileEditorManagerEx.getInstanceEx(psiFile.getProject).getSelectedTextEditor).map(_.getCaretModel.getCurrentCaret.getOffset)
-    offset.map(psiFile.findElementAt)
   }
 
   def showHaskellSupportIsNotAvailableWhileInitializing(project: Project): Unit = {

--- a/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
+++ b/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
@@ -57,21 +57,16 @@ object HaskellEditorUtil {
       presentation.setVisible(false)
     }
 
-    try {
-      val dataContext = actionEvent.getDataContext
-      val psiFile = CommonDataKeys.PSI_FILE.getData(dataContext)
-      if (HaskellProjectUtil.isHaskellProject(psiFile.getProject)) {
-        psiFile match {
-          case _: HaskellFile if !onlyForSourceFile => enable()
-          case _: HaskellFile if onlyForSourceFile && HaskellProjectUtil.isSourceFile(psiFile) => enable()
-          case _ => disable()
-        }
-      } else {
-        disable()
+    val dataContext = actionEvent.getDataContext
+    val psiFile = CommonDataKeys.PSI_FILE.getData(dataContext)
+    if (HaskellProjectUtil.isHaskellProject(psiFile.getProject)) {
+      psiFile match {
+        case _: HaskellFile if !onlyForSourceFile => enable()
+        case _: HaskellFile if onlyForSourceFile && HaskellProjectUtil.isSourceFile(psiFile) => enable()
+        case _ => disable()
       }
-    }
-    catch {
-      case _: Exception => disable()
+    } else {
+      disable()
     }
   }
 

--- a/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
+++ b/src/main/scala/me/fornever/haskeletor/util/HaskellEditorUtil.scala
@@ -51,15 +51,15 @@ object HaskellEditorUtil {
     }
 
     val dataContext = actionEvent.getDataContext
-    val psiFile = CommonDataKeys.PSI_FILE.getData(dataContext)
-    if (HaskellProjectUtil.isHaskellProject(psiFile.getProject)) {
-      psiFile match {
-        case _: HaskellFile if !onlyForSourceFile => enable()
-        case _: HaskellFile if onlyForSourceFile && HaskellProjectUtil.isSourceFile(psiFile) => enable()
-        case _ => disable()
-      }
-    } else {
-      disable()
+    val psiFile = Option(CommonDataKeys.PSI_FILE.getData(dataContext))
+    psiFile match {
+      case Some(psiFile: HaskellFile) if HaskellProjectUtil.isHaskellProject(psiFile.getProject) =>
+        if (!onlyForSourceFile || HaskellProjectUtil.isSourceFile(psiFile)) {
+          enable()
+        } else {
+          disable()
+        }
+      case _ => disable()
     }
   }
 


### PR DESCRIPTION
Previously, this has led to hard-to-investigate issues.