### PR TITLE
GlobalInfo: clean up old code for jdk.lang.Process.allowAmbiguousCommands

### DIFF
--- a/settings/src/main/scala/me/fornever/haskeletor/settings/GlobalInfo.scala
+++ b/settings/src/main/scala/me/fornever/haskeletor/settings/GlobalInfo.scala
@@ -19,16 +19,11 @@ import java.io.File
 
 object GlobalInfo {
 
-  final val LibrarySourcedDirName = "lib"
-  final val StackWorkDirName = ".stack-work"
+  private final val LibrarySourcedDirName = "lib"
   final val StackageLtsVersion = "lts-19"
   private final val ToolsBinDirName = "bin"
 
-  final lazy val DefaultCachePath = {
-    // Workaround https://github.com/rikvdkleij/intellij-haskell/issues/503
-    if (SystemInfo.isWindows) {
-      System.setProperty("jdk.lang.Process.allowAmbiguousCommands", "true")
-    }
+  private final lazy val DefaultCachePath = {
     ProjectDirectories.from("me.fornever", "", "haskeletor").cacheDir
   }
 


### PR DESCRIPTION
This was initially introduced as a workaround for https://github.com/dirs-dev/directories-jvm/issues/26, which's been fixed since.