### PR TITLE
HaskellProjectManager: fix warning on index access during buildSearchableOptions

### DIFF
--- a/projectModel/src/main/kotlin/me/fornever/haskeletor/projectmodel/HaskellProjectManager.kt
+++ b/projectModel/src/main/kotlin/me/fornever/haskeletor/projectmodel/HaskellProjectManager.kt
@@ -79,7 +79,9 @@ class HaskellProjectManager(private val project: Project) {
                 }
             })
         }
-        launchInitialCheck()
+        if (!project.isDefault) {
+            launchInitialCheck()
+        }
     }
 
     private fun launchInitialCheck() {


### PR DESCRIPTION


Fixes "#c.i.w.c.f.i.WorkspaceFileIndexImpl - WorkspaceFileIndex must not be queried for the default project".