### PR TITLE
fix: skip non-local VFS files before path conversion

### DIFF
--- a/projectModel/src/main/kotlin/me/fornever/haskeletor/projectmodel/HaskellProjectManager.kt
+++ b/projectModel/src/main/kotlin/me/fornever/haskeletor/projectmodel/HaskellProjectManager.kt
@@ -141,7 +141,10 @@ class HaskellProjectManager(private val project: Project) {
     }
 
     private fun processConfigFile(file: VirtualFile, exists: Boolean) {
-        if (!isConfigFile(file.toNioPath())) return
+        if (!file.isInLocalFileSystem) return
+
+        val path = file.toNioPath()
+        if (!isConfigFile(path)) return
 
         val projectFileIndex = ProjectFileIndex.getInstance(project)
         val shouldExist = exists && projectFileIndex.isInContent(file)
@@ -150,7 +153,7 @@ class HaskellProjectManager(private val project: Project) {
                 " Exists: $exists, isInContent: ${projectFileIndex.isInContent(file)}."
         }
 
-        modifyConfigFileMap(file.toNioPath(), shouldExist)
+        modifyConfigFileMap(path, shouldExist)
     }
 
     private fun replaceConfigFiles(paths: Set<Path>) {


### PR DESCRIPTION
## Summary

Fixes #88.

Skip non-local virtual files before converting them to `Path` in `HaskellProjectManager`. This avoids calling `VirtualFile.toNioPath()` for jar-backed VFS entries, which can throw before config-file filtering runs.

## Testing

- `git diff --check`
- `./gradlew :projectModel:compileKotlin --no-daemon` with a local JDK 21
